### PR TITLE
Feature/frontend build support

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -62,7 +62,7 @@ parameters:
 - name: 'npmExternalFeed'
   type: string
   default: ''
-  displayName: 'If your frontend uses an external feed (i.e. via an npm service connection'), the name of the service connection'
+  displayName: 'If your frontend uses an external feed (i.e. via an npm service connection), the name of the service connection'
 
 steps:
 - ${{ if ne(parameters.DotNetSdkVersion, '') }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -51,6 +51,19 @@ parameters:
   default: ''
   displayName: 'Names of external NuGet feed links. '
 
+- name: 'withFrontend'
+  type: boolean
+  default: false
+  displayName: 'Does your frontend contain a separate frontend build (i.e. npm run build)'
+- name: 'frontendRootFolder'
+  type: string
+  default: ''
+  displayName: 'The root folder of your frontend project'
+- name: 'npmExternalFeed'
+  type: string
+  default: ''
+  displayName: 'If your frontend uses an external feed (i.e. via an npm service connection'), the name of the service connection'
+
 steps:
 - ${{ if ne(parameters.DotNetSdkVersion, '') }}:
   - task: UseDotNet@2
@@ -93,12 +106,29 @@ steps:
     custom: 'tool'
     arguments: 'restore'
 
+- ${{ if parameters.withFrontend }}
+  - task: Npm@1
+    displayName: 'npm install'
+    inputs:
+      command: 'install'
+      workingDir: '${{ parameters.frontendRootFolder }}'
+      ${{ if ne(parameters.npmExternalFeed, '') }}
+        customEndpoint: Npm-DlwPro-StaticSite
+
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Build'
   inputs:
     command: 'build'
     projects: ${{ parameters.Solution }}
     arguments: '--configuration ${{ parameters.BuildConfiguration }} /p:Platform="${{ parameters.BuildPlatform }}" --no-restore'
+
+- ${{ if parameters.withFrontend }}
+  - task: Npm@1
+    displayName: 'npm build'
+    inputs:
+      command: 'custom'
+      customCommand: 'run build'
+      workingDir: '${{ parameters.frontendRootFolder }}'
 
 - ${{ if ne(parameters.NoTests, 'true') }}:
   - ${{ each step in parameters.BeforeTestsSteps }}:
@@ -109,6 +139,14 @@ steps:
       command: 'test'
       projects: '**/*[Tt]ests/*.csproj'
       arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build'
+  - ${{ if parameters.withFrontend }}
+    - task: Npm@1
+      displayName: 'npm test'
+      enabled: false
+      inputs:
+        command: 'custom'
+        customCommand: 'run test'
+        workingDir: '${{ parameters.frontendRootFolder }}'
 
 - ${{ if eq(parameters.WithPack, 'true') }}:
   - task: DotNetCoreCLI@2
@@ -120,6 +158,12 @@ steps:
       arguments: '--configuration $(BuildConfiguration) --no-restore --no-build'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
+  - ${{ if and(eq(parameters.withFrontend, 'true'), ne(parameters.npmExternalFeed, '')) }}
+    - task: npmAuthenticate@0
+      displayName: 'npm Authenticate'
+      inputs:
+        workingFile: '${{ parameters.frontendRootFolder }}\.npmrc'
+        customEndpoint: '${{ parameters.npmExternalFeed }}'
   - task: DotNetCoreCLI@2
     displayName: 'DotNet Publish'
     inputs:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -106,13 +106,13 @@ steps:
     custom: 'tool'
     arguments: 'restore'
 
-- ${{ if parameters.withFrontend }}
+- ${{ if parameters.withFrontend }}:
   - task: Npm@1
     displayName: 'npm install'
     inputs:
       command: 'install'
       workingDir: '${{ parameters.frontendRootFolder }}'
-      ${{ if ne(parameters.npmExternalFeed, '') }}
+      ${{ if ne(parameters.npmExternalFeed, '') }}:
         customEndpoint: Npm-DlwPro-StaticSite
 
 - task: DotNetCoreCLI@2
@@ -122,7 +122,7 @@ steps:
     projects: ${{ parameters.Solution }}
     arguments: '--configuration ${{ parameters.BuildConfiguration }} /p:Platform="${{ parameters.BuildPlatform }}" --no-restore'
 
-- ${{ if parameters.withFrontend }}
+- ${{ if parameters.withFrontend }}:
   - task: Npm@1
     displayName: 'npm build'
     inputs:
@@ -139,7 +139,7 @@ steps:
       command: 'test'
       projects: '**/*[Tt]ests/*.csproj'
       arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build'
-  - ${{ if parameters.withFrontend }}
+  - ${{ if parameters.withFrontend }}:
     - task: Npm@1
       displayName: 'npm test'
       enabled: false
@@ -158,7 +158,7 @@ steps:
       arguments: '--configuration $(BuildConfiguration) --no-restore --no-build'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
-  - ${{ if and(eq(parameters.withFrontend, 'true'), ne(parameters.npmExternalFeed, '')) }}
+  - ${{ if and(eq(parameters.withFrontend, 'true'), ne(parameters.npmExternalFeed, '')) }}:
     - task: npmAuthenticate@0
       displayName: 'npm Authenticate'
       inputs:


### PR DESCRIPTION
Added support for SPA frontends via three new parameters:
- withFrontend: boolean
Enables building of a frontend project via npm
- frontendRootFolder: string
The root folder of the frontend project, containing the package.json etc.
- npmExternalFeed: string
If the frontend project uses an external npm feed via an Azure Devops Service Connection, then configure the name of that service connection here. This is required to authenticate npm