### PR TITLE
No NuGet tool and package caching

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -34,14 +34,6 @@ parameters:
   default: false
   displayName: 'Whether to run ''dotnet publish''.'
 
-- name: WithNuGetTool
-  type: boolean
-  default: false
-  displayName: 'Whether to use NuGet tool and no only rely on ''dotnet restore''.'
-- name: NuGetToolVersion
-  type: string
-  default: '5.4.0'
-  displayName: 'Specific NuGet tool version to use.'
 - name: NuGetConfigPath
   type: string
   default: '.nuget/NuGet.Config'
@@ -60,22 +52,12 @@ steps:
       version: ${{ parameters.DotNetSdkVersion }}
       includePreviewVersions: true
 
-- ${{ if eq(parameters.WithNuGetTool, true) }}:
-  # dotnet restore does not yet work with external Azure Devops Artifacts: https://github.com/microsoft/azure-pipelines-tasks/issues/7160
-  - task: NuGetToolInstaller@1
-    displayName: 'Use specific NuGet tool ${{ parameters.NuGetToolVersion }}'
+- ${{ if ne(parameters.ExternalFeedCredentials, '') }}:
+  - task: NuGetAuthentiate@0
+    displayName: 'NuGet Authenticate'
     inputs:
-      versionSpec: ${{ parameters.NuGetToolVersion }}
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore'
-    inputs:
-      command: 'restore'
-      restoreSolution: ${{ parameters.Solution }}
-      feedsToUse: 'config'
-      nugetConfigPath: ${{ parameters.NuGetConfigPath }}
-      externalFeedCredentials: ${{ parameters.ExternalFeedCredentials }}
-  
-# dotnet restore still seems necessary, see https://stackoverflow.com/questions/48440223/assets-file-project-assets-json-not-found-run-a-nuget-package-restore
+      nuGetServiceConnections: ${{ parameters.ExternalFeedCredentials }}
+
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'
   inputs: 

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -66,7 +66,7 @@ steps:
   - task: Cache@2
     displayName: Cache NuGet packages
     inputs:
-      key: 'nuget | "$(Agent.OS)" | **/packages.lock.json,!**/bin/**'
+      key: 'nuget | "$(Agent.OS)"'
       restoreKeys: |
          nuget | "$(Agent.OS)"
       path: $(Pipeline.Workspace)/.nuget/packages

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -53,7 +53,7 @@ steps:
       includePreviewVersions: true
 
 - ${{ if ne(parameters.ExternalFeedCredentials, '') }}:
-  - task: NuGetAuthentiate@0
+  - task: NuGetAuthenticate@0
     displayName: 'NuGet Authenticate'
     inputs:
       nuGetServiceConnections: ${{ parameters.ExternalFeedCredentials }}

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -45,7 +45,7 @@ parameters:
 - name: WithNuGetCache
   type: boolean
   default: true
-  displayName: 'Whether to cache NuGet packages.'
+  displayName: 'Whether to cache NuGet packages. NUGET_PACKAGES environment variable still needs to be set though.'
 
 steps:
 - ${{ if ne(parameters.DotNetSdkVersion, '') }}:
@@ -70,6 +70,7 @@ steps:
       restoreKeys: |
          nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)
+    condition: ne($(NUGET_PACKAGES), '')
   
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -70,7 +70,7 @@ steps:
       restoreKeys: |
          nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)
-    condition: ne($(NUGET_PACKAGES), '')
+    condition: ne(variables.NUGET_PACKAGES, '')
   
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -64,11 +64,13 @@ steps:
 
 - ${{ if eq(parameters.WithNuGetCache, 'true') }}:
   - task: Cache@2
-    displayName: Cache NuGet packages
+    displayName: NuGet Package Caching
     inputs:
-      key: 'nuget | "$(Agent.OS)"'
+      # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
+      # We mainly want to optimize waiting for PR builds.
+      key: 'nuget | "$(Agent.OS)" | $(Get-Date -Format yyyyMMdd)'
       restoreKeys: |
-         nuget | "$(Agent.OS)"
+        nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)
     condition: ne(variables.NUGET_PACKAGES, '')
   

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -68,7 +68,7 @@ steps:
     inputs:
       # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
       # We mainly want to optimize waiting for PR builds.
-      key: 'nuget | "$(Agent.OS)" | $(Get-Date -Format yyyyMMdd)'
+      key: 'nuget | "$(Agent.OS)" | "$(Get-Date -Format yyyyMMdd)"'
       restoreKeys: |
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -33,6 +33,10 @@ parameters:
   type: boolean
   default: false
   displayName: 'Whether to run ''dotnet publish''.'
+- name: WithNuGetPush
+  type: boolean
+  default: false
+  displayName: 'Whether to run ''dotnet nuget push'' for default defaultPushSource in NuGet config file.'
 
 - name: NuGetConfigPath
   type: string
@@ -130,3 +134,10 @@ steps:
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false
+
+- ${{ if eq(parameters.WithNuGetPush, 'true') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'DotNet NuGet Push'
+    inputs:
+      command: 'nuget'
+      arguments: 'push $(Build.ArtifactStagingDirectory)/*.*nupkg --skip-duplicate'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -68,7 +68,7 @@ steps:
     inputs:
       # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
       # We mainly want to optimize waiting for PR builds.
-      key: 'nuget | "$(Agent.OS)" | "$[format('{0:yyyyMMdd}', pipeline.startTime)]"'
+      key: nuget | $(Agent.OS) | $[format('{0:yyyyMMdd}', pipeline.startTime)]
       restoreKeys: |
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -42,6 +42,13 @@ parameters:
   type: string
   default: ''
   displayName: 'Names of external NuGet feed links. '
+- name: WithNuGetCache
+  type: boolean
+  default: true
+  displayName: 'Whether to cache NuGet packages.'
+
+variables:
+  NuGetPackages: $(Pipeline.Workspace)/.nuget/packages
 
 steps:
 - ${{ if ne(parameters.DotNetSdkVersion, '') }}:
@@ -58,6 +65,15 @@ steps:
     inputs:
       nuGetServiceConnections: ${{ parameters.ExternalFeedCredentials }}
 
+- ${{ if eq(parameters.WithNuGetCache, 'true') }}:
+  - task: Cache@2
+    displayName: Cache NuGet packages
+    inputs:
+      key: 'nuget | "$(Agent.OS)" | **/packages.lock.json,!**/bin/**'
+      restoreKeys: |
+         nuget | "$(Agent.OS)"
+      path: $(NUGET_PACKAGES)
+  
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'
   inputs: 
@@ -67,6 +83,7 @@ steps:
       feedsToUse: 'config'
       nugetConfigPath: ${{ parameters.NuGetConfigPath }}
       externalFeedCredentials: ${{ parameters.ExternalFeedCredentials }}
+      restoreArguments: --locked-mode
 
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Tool Restore'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -63,12 +63,14 @@ steps:
       nuGetServiceConnections: ${{ parameters.ExternalFeedCredentials }}
 
 - ${{ if eq(parameters.WithNuGetCache, 'true') }}:
+  # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
+  # We mainly want to optimize waiting for PR builds.
+  - pwsh: echo "##vso[task.setvariable variable=NuGetCacheKey]$(Get-Date -Format yyyyMMdd)"
+    displayName: NuGet Package Cache Key
   - task: Cache@2
     displayName: NuGet Package Caching
     inputs:
-      # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
-      # We mainly want to optimize waiting for PR builds.
-      key: nuget | $(Agent.OS) | $[format('{0:yyyyMMdd}', pipeline.startTime)]
+      key: nuget | "$(Agent.OS)" | "$(NuGetCacheKey)"
       restoreKeys: |
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -29,14 +29,14 @@ parameters:
   type: boolean
   default: false
   displayName: 'Whether to run ''dotnet package''.'
+- name: WithPush
+  type: boolean
+  default: false
+  displayName: 'Whether to run ''dotnet nuget push'' for default defaultPushSource in NuGet config file.'
 - name: WithPublish
   type: boolean
   default: false
   displayName: 'Whether to run ''dotnet publish''.'
-- name: WithNuGetPush
-  type: boolean
-  default: false
-  displayName: 'Whether to run ''dotnet nuget push'' for default defaultPushSource in NuGet config file.'
 
 - name: NuGetConfigPath
   type: string
@@ -124,6 +124,14 @@ steps:
       versioningScheme: 'off'
       arguments: '--configuration $(BuildConfiguration) --no-restore --no-build'
 
+- ${{ if eq(parameters.WithPush, 'true') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'DotNet Push'
+    inputs:
+      command: 'push'
+      searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg'
+      externalEndPoint: ${{ parameters.ExternalFeedCredentials }}
+
 - ${{ if eq(parameters.WithPublish, 'true') }}:
   - task: DotNetCoreCLI@2
     displayName: 'DotNet Publish'
@@ -134,10 +142,3 @@ steps:
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false
-
-- ${{ if eq(parameters.WithNuGetPush, 'true') }}:
-  - task: DotNetCoreCLI@2
-    displayName: 'DotNet NuGet Push'
-    inputs:
-      command: 'nuget'
-      arguments: 'push $(Build.ArtifactStagingDirectory)/*.*nupkg --skip-duplicate'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -68,7 +68,7 @@ steps:
     inputs:
       # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
       # We mainly want to optimize waiting for PR builds.
-      key: 'nuget | "$(Agent.OS)" | "$(Date:yyyyMMdd)"'
+      key: 'nuget | "$(Agent.OS)" | "$[format('{0:yyyyMMdd}', pipeline.startTime)]"'
       restoreKeys: |
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -29,10 +29,6 @@ parameters:
   type: boolean
   default: false
   displayName: 'Whether to run ''dotnet package''.'
-- name: WithPush
-  type: boolean
-  default: false
-  displayName: 'Whether to run ''dotnet nuget push'' for default defaultPushSource in NuGet config file.'
 - name: WithPublish
   type: boolean
   default: false
@@ -123,14 +119,6 @@ steps:
       packagesToPack: ${{ parameters.Solution }}
       versioningScheme: 'off'
       arguments: '--configuration $(BuildConfiguration) --no-restore --no-build'
-
-- ${{ if eq(parameters.WithPush, 'true') }}:
-  - task: DotNetCoreCLI@2
-    displayName: 'DotNet Push'
-    inputs:
-      command: 'push'
-      searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg'
-      externalEndPoint: ${{ parameters.ExternalFeedCredentials }}
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
   - task: DotNetCoreCLI@2

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -69,7 +69,7 @@ steps:
       key: 'nuget | "$(Agent.OS)"'
       restoreKeys: |
          nuget | "$(Agent.OS)"
-      path: $(Pipeline.Workspace)/.nuget/packages
+      path: $(NUGET_PACKAGES)
   
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -68,7 +68,7 @@ steps:
     inputs:
       # As we don't use package lock files, we want to make sure our cache isn't too far behind the dotnet restore.
       # We mainly want to optimize waiting for PR builds.
-      key: 'nuget | "$(Agent.OS)" | "$(Get-Date -Format yyyyMMdd)"'
+      key: 'nuget | "$(Agent.OS)" | "$(Date:yyyyMMdd)"'
       restoreKeys: |
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -47,9 +47,6 @@ parameters:
   default: true
   displayName: 'Whether to cache NuGet packages.'
 
-variables:
-  NuGetPackages: $(Pipeline.Workspace)/.nuget/packages
-
 steps:
 - ${{ if ne(parameters.DotNetSdkVersion, '') }}:
   - task: UseDotNet@2
@@ -72,7 +69,7 @@ steps:
       key: 'nuget | "$(Agent.OS)" | **/packages.lock.json,!**/bin/**'
       restoreKeys: |
          nuget | "$(Agent.OS)"
-      path: $(NUGET_PACKAGES)
+      path: $(Pipeline.Workspace)/.nuget/packages
   
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'


### PR DESCRIPTION
Removed the dependency on the NuGet tool because dotnet restore now works with NuGetAuthenticate
This is a breaking change because 'WithNuGetTool' and 'WithNuGetTool' parameters have been removed.

Added support for caching nugets.
To opt-in, configure variable NUGET_PACKAGES to e.g. '$(Pipeline.Workspace)/.nuget/packages'