### PR TITLE
Fix passing pack arguments

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -148,7 +148,7 @@ steps:
       command: 'custom'
       custom: 'pack'
       projects: ${{ parameters.Solution }}
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build --output $(Build.ArtifactStagingDirectory)'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
   - task: DotNetCoreCLI@2

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -147,7 +147,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'pack'
-      packagesToPack: ${{ parameters.Solution }}
+      projects: ${{ parameters.Solution }}
       arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -145,10 +145,10 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: 'DotNet Pack'
     inputs:
-      command: 'pack'
+      command: 'custom'
+      custom: 'pack'
       packagesToPack: ${{ parameters.Solution }}
-      versioningScheme: 'off'
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
`dotnet pack` arguments are not being passed to the command using the dotnet pack task. Using dotnet custom command to fix this.