### PR TITLE
allow additional dotnet test arguments

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -17,6 +17,10 @@ parameters:
   default: ''
   displayName: 'Specific .NET SDK version to use.'
 
+- name: TestArguments
+  type: string
+  default: ''
+  displayName: 'Optional arguments to pass to test runner.'
 - name: BeforeTestsSteps
   type: stepList
   default: []
@@ -71,11 +75,6 @@ parameters:
   type: string
   default: ''
   displayName: 'Optional Azure Subscription to run ''dotnet test'' under Azure CLI context. So you can access Azure resources (like App Configuration, Key Vault, etc) with authenticated credentials.'
-
-- name: TestArguments
-  type: string
-  default: ''
-  displayName: 'Optional arguments to pass to test runner.'
 
 steps:
 - ${{ if ne(parameters.NuGetToolVersion, '') }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -72,6 +72,11 @@ parameters:
   default: ''
   displayName: 'Optional Azure Subscription to run ''dotnet test'' under Azure CLI context. So you can access Azure resources (like App Configuration, Key Vault, etc) with authenticated credentials.'
 
+- name: TestArguments
+  type: string
+  default: ''
+  displayName: 'Optional arguments to pass to test runner.'
+
 steps:
 - ${{ if ne(parameters.NuGetToolVersion, '') }}:
   # Hosted build agent windows-2022 doesn't seem to auto select right nuget version, so we allow to set it explicitly.
@@ -184,7 +189,7 @@ steps:
       inputs:
         command: 'test'
         projects: '**/*[Tt]ests/*.csproj'
-        arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build'
+        arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build ${{ parameters.TestArguments }}'
       condition: succeededOrFailed()
 
   - ${{ else }}:


### PR DESCRIPTION
allows adding additional arguments to the `dotnet test` task.
for example:
```
  - template: azure/pipelines/dotnet/ci.yml@scripts
    parameters:
      ...
      testArguments: --collect:"XPlat Code Coverage" --settings:"coverlet.runsettings"
```