### PR TITLE
allow passing custom glob path for test projects

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -17,6 +17,10 @@ parameters:
   default: ''
   displayName: 'Specific .NET SDK version to use.'
 
+- name: TestProjectGlob
+  type: string
+  default: '**/*[Tt]ests/*.csproj'
+  displayName: 'Glob to match test projects.'
 - name: TestArguments
   type: string
   default: ''
@@ -187,7 +191,7 @@ steps:
       displayName: 'DotNet Test'
       inputs:
         command: 'test'
-        projects: '**/*[Tt]ests/*.csproj'
+        projects: ${{ parameters.TestProjectGlob }}
         arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build ${{ parameters.TestArguments }}'
       condition: succeededOrFailed()
 

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -17,7 +17,7 @@ parameters:
   default: ''
   displayName: 'Specific .NET SDK version to use.'
 
-- name: TestProjectGlob
+- name: TestProjectsGlob
   type: string
   default: '**/*[Tt]ests/*.csproj'
   displayName: 'Glob to match test projects.'
@@ -191,7 +191,7 @@ steps:
       displayName: 'DotNet Test'
       inputs:
         command: 'test'
-        projects: ${{ parameters.TestProjectGlob }}
+        projects: ${{ parameters.TestProjectsGlob }}
         arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build ${{ parameters.TestArguments }}'
       condition: succeededOrFailed()
 


### PR DESCRIPTION
example:
```
  - template: azure/pipelines/dotnet/ci.yml@scripts
    parameters:
      testProjectGlob: '**/*[Tt]ests?(.)*/*.csproj'
```