### PR TITLE
Fix dotnet publish 'NoBuild' issues

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -166,12 +166,10 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: 'DotNet Publish'
     inputs:
-      command: 'publish'
+      command: 'custom'
+      custom: 'publish'
       projects: ${{ parameters.Solution }}
       arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build --output $(Build.ArtifactStagingDirectory)\packages'
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
 
 - ${{ if ne(parameters.NoTests, 'true') }}:
   - ${{ each step in parameters.BeforeTestsSteps }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -166,10 +166,12 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: 'DotNet Publish'
     inputs:
-      command: 'custom'
-      custom: 'publish'
+      command: 'publish'
       projects: ${{ parameters.Solution }}
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --no-build --output $(Build.ArtifactStagingDirectory)\packages'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --output $(Build.ArtifactStagingDirectory)\packages'
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
 
 - ${{ if ne(parameters.NoTests, 'true') }}:
   - ${{ each step in parameters.BeforeTestsSteps }}:


### PR DESCRIPTION
Since .NET 6 we get the following error in some cases: "error NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.".
Seems to be an issue with projects that use the "Microsoft.NET.Sdk.Razor" project SDK.