### PR TITLE
fix output path for .net 7 builds

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -166,6 +166,9 @@ steps:
       command: 'custom'
       custom: 'pack'
       projects: ${{ parameters.Solution }}
+      # Since .NET SDK 7.0.200 output parameter is not supported anymore on solution builds.
+      # See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid
+      # As we really want to perform solution builds/publishes, we use the workaround to specify the 'PackageOutputPath' property.
       arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property:PackageOutputPath=$(Build.ArtifactStagingDirectory)'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
@@ -174,6 +177,9 @@ steps:
     inputs:
       command: 'publish'
       projects: ${{ parameters.Solution }}
+      # Since .NET SDK 7.0.200 output parameter is not supported anymore on solution builds.
+      # See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid
+      # As we really want to perform solution builds/publishes, we use the workaround to specify the 'PublishDir' property.
       arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property:PublishDir=$(Build.ArtifactStagingDirectory)/packages'
       publishWebProjects: false
       modifyOutputPath: false

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -166,7 +166,7 @@ steps:
       command: 'custom'
       custom: 'pack'
       projects: ${{ parameters.Solution }}
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --output $(Build.ArtifactStagingDirectory)'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property:PackageOutputPath=$(Build.ArtifactStagingDirectory)'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
   - task: DotNetCoreCLI@2
@@ -174,7 +174,7 @@ steps:
     inputs:
       command: 'publish'
       projects: ${{ parameters.Solution }}
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --output $(Build.ArtifactStagingDirectory)/packages'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property:PublishDir=$(Build.ArtifactStagingDirectory)/packages'
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false


### PR DESCRIPTION
using `--output` generates error/warning in .net sdk >= 7.0.200

See: https://github.com/dotnet/sdk/issues/30624#issuecomment-1432118204