### PR TITLE
Revert pack command back to custom command

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -164,12 +164,17 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: 'DotNet Pack'
     inputs:
-      command: 'pack'
-      packagesToPack: ${{ parameters.Solution }}
-      # Since .NET SDK 7.0.200 output parameter is not supported anymore on solution builds.
-      # See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid
-      # As we really want to perform solution builds publishes, we use the workaround to specify the 'PackageOutputPath' property.
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property PackageOutputPath=$(Build.ArtifactStagingDirectory)/nugets'
+      # Reverted to a 'custom' command. The 'pack' and 'push' command of 'DotNetCoreCLI@2' ignores the 'arguments' parameter.
+      # Follow-up: https://github.com/microsoft/azure-pipelines-tasks/issues/11640.
+      command: 'custom'
+      custom: 'pack'
+      projects: ${{ parameters.Solution }}
+      # Version .NET SDK 7.0.200 does not support output parameter on solution builds.
+      # See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.
+      # Starting from SDK 7.0.201, this does not apply to 'dotnet pack' and has been degraded to a warning for other dotnet commands.
+      # As we really want to perform solution builds/publishes and as long we have build agents that runs on 7.0.200,
+      # we use the workaround to specify the 'PackageOutputPath' property.
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property:PackageOutputPath=$(Build.ArtifactStagingDirectory)/nugets'
 
 - ${{ if eq(parameters.WithPublish, 'true') }}:
   - task: DotNetCoreCLI@2
@@ -177,9 +182,11 @@ steps:
     inputs:
       command: 'publish'
       projects: ${{ parameters.Solution }}
-      # Since .NET SDK 7.0.200 output parameter is not supported anymore on solution builds.
-      # See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid
-      # As we really want to perform solution builds/publishes, we use the workaround to specify the 'PublishDir' property.
+      # Version .NET SDK 7.0.200 does not support output parameter on solution builds.
+      # See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.
+      # Starting from SDK 7.0.201, this has been degraded to a warning for other dotnet commands.
+      # As we really want to perform solution builds/publishes and as long we have build agents that runs on 7.0.200,
+      # we use the workaround to specify the 'PublishDir' property.
       arguments: '--configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} --property PublishDir=$(Build.ArtifactStagingDirectory)/packages'
       publishWebProjects: false
       modifyOutputPath: false

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -249,7 +249,7 @@ steps:
       displayName: 'DotNet Push'
       inputs:
         command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/nugets/*.nupkg;$(Build.ArtifactStagingDirectory)/nugets/*.snupkg;!$(Build.ArtifactStagingDirectory)/nugets/*.symbols.nupkg'
         nuGetFeedType: 'external'
         publishFeedCredentials: $(externalFeedCredentials)
 
@@ -259,7 +259,7 @@ steps:
       displayName: 'DotNet Push'
       inputs:
         command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/nugets/*.nupkg;$(Build.ArtifactStagingDirectory)/nugets/*.snupkg;!$(Build.ArtifactStagingDirectory)/nugets/*.symbols.nupkg'
         nuGetFeedType: 'internal'
         publishVstsFeed: ${{ parameters.InternalFeedName }}
 


### PR DESCRIPTION
- 'arguments' command doesn't apply to 'pack' and 'push' command of DotNetCoreCLI@2. (See: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2?view=azure-pipelines)
- Didn't revert 'push' as we don't need to specify arguments.
- Added some extra info regarding 'output' parameter.

Change request seems to be accepted by MS.
Follow-up here: https://github.com/microsoft/azure-pipelines-tasks/issues/11640