### PR TITLE
Use webAppSlot value instead of trying to recreate it

### DIFF
--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -56,6 +56,7 @@ steps:
           Write-Host 'Web app name: ''${{ parameters.webApp }}'''
           Write-Host "##vso[task.setVariable variable=skipWebApp]false"
       }
+      # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
       Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"
 
 - task: AzureRmWebAppDeployment@4

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -36,9 +36,6 @@ parameters:
   default: []
   displayName: 'Optional steps to execute after production slot deploy, before cleaning up the old slot (when applicable).'
 
-variables:
-    webAppSlotName: $[ parameters.webAppSlot ]
-
 steps:
 - task: PowerShell@2
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Check preconditions'
@@ -59,6 +56,7 @@ steps:
           Write-Host 'Web app name: ''${{ parameters.webApp }}'''
           Write-Host "##vso[task.setVariable variable=skipWebApp]false"
       }
+      Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -36,6 +36,9 @@ parameters:
   default: []
   displayName: 'Optional steps to execute after production slot deploy, before cleaning up the old slot (when applicable).'
 
+variables:
+    webAppSlotName: $[ parameters.webAppSlot ]
+
 steps:
 - task: PowerShell@2
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Check preconditions'
@@ -89,7 +92,7 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup }}
       SourceSlot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne($[ parameters.webAppSlot ], 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
 
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
@@ -102,4 +105,4 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne($[ parameters.webAppSlot ], 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -89,7 +89,7 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup }}
       SourceSlot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(${{ parameters.webAppSlot }}, 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne($[ parameters.webAppSlot ], 'production'))
 
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
@@ -102,4 +102,4 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(${{ parameters.webAppSlot }}, 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne($[ parameters.webAppSlot ], 'production'))

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -3,10 +3,6 @@ parameters:
 - name: azureSubscription
   type: string
   displayName: 'Azure Subscription to deploy to.'
-- name: variablePrefix
-  type: string
-  displayName: 'Prefix used in output variables from Platina provision CLI.'
-  default: 'Platina'
 - name: module
   type: string
   displayName: 'Platina module name.'
@@ -93,7 +89,7 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup }}
       SourceSlot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['${{ parameters.variablePrefix }}${{ parameters.module }}WebAppSlot'], 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(${{ parameters.webAppSlot }}, 'production'))
 
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
@@ -106,4 +102,4 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['${{ parameters.variablePrefix }}${{ parameters.module }}WebAppSlot'], 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(${{ parameters.webAppSlot }}, 'production'))


### PR DESCRIPTION
- Clean up variablePrefix as we do not use it anymore
- Use the value of the parameter webAppSlot instead of trying to generate the variable name. (Fixes component part missing from name)