### PR TITLE
Add possibility to stop the staging slot after swap, instead of deleting it.

### DIFF
--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -100,7 +100,7 @@ steps:
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
 
-  - ${{ if not(parameters.keepStagingSlot }}:
+  - ${{ if not(parameters.keepStagingSlot) }}:
 
     - task: AzureAppServiceManage@0
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -61,7 +61,7 @@ steps:
           Write-Host "##vso[task.setVariable variable=skipWebApp]false"
       }
       # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
-      Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"     
+      Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -103,6 +103,7 @@ steps:
     - ${{ step }} 
 
   - ${{ if not(variables['keepStagingSlot']) }}
+
     - task: AzureAppServiceManage@0
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
       inputs:
@@ -114,6 +115,7 @@ steps:
       condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
   
   - ${{ if variables['keepStagingSlot'] }}
+  
     - task: AzureAppServiceManage@0
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
       inputs:

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -100,19 +100,27 @@ steps:
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
 
-  - task: AzureAppServiceManage@0
-    ${{ if parameters.keepStagingSlot }}
-      displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
-    ${{ else }}
+  - ${{ if not(parameters.keepStagingSlot }}:
+
+    - task: AzureAppServiceManage@0
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
-    inputs:
-      azureSubscription: ${{ parameters.azureSubscription }}
-      ${{ if parameters.keepStagingSlot }}
-        Action: 'Stop Azure App Service'
-        SpecifySlotOrASE: true
-      ${{ else }}
+      inputs:
+        azureSubscription: ${{ parameters.azureSubscription }}
         Action: 'Delete Slot'
-      WebAppName: ${{ parameters.webApp }}
-      ResourceGroupName: ${{ parameters.webAppResourceGroup}}
-      Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
+        WebAppName: ${{ parameters.webApp }}
+        ResourceGroupName: ${{ parameters.webAppResourceGroup}}
+        Slot: ${{ parameters.webAppSlot }}
+      condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
+  
+  - ${{ if parameters.keepStagingSlot}}:
+
+    - task: AzureAppServiceManage@0
+      displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
+      inputs:
+        azureSubscription: ${{ parameters.azureSubscription }}
+        Action: 'Stop Azure App Service'
+        WebAppName: ${{ parameters.webApp }}
+        ResourceGroupName: ${{ parameters.webAppResourceGroup}}
+        SpecifySlotOrASE: true
+        Slot: ${{ parameters.webAppSlot }}
+      condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -100,27 +100,19 @@ steps:
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
 
-  - ${{ if not(parameters.keepStagingSlot }}
-
-    - task: AzureAppServiceManage@0
-      displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
-      inputs:
-        azureSubscription: ${{ parameters.azureSubscription }}
-        Action: 'Delete Slot'
-        WebAppName: ${{ parameters.webApp }}
-        ResourceGroupName: ${{ parameters.webAppResourceGroup}}
-        Slot: ${{ parameters.webAppSlot }}
-      condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
-  
-  - ${{ if parameters.keepStagingSlot }}
-
-    - task: AzureAppServiceManage@0
+  - task: AzureAppServiceManage@0
+    ${{ if parameters.keepStagingSlot }}
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
-      inputs:
-        azureSubscription: ${{ parameters.azureSubscription }}
+    ${{ else }}
+      displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      ${{ if parameters.keepStagingSlot }}
         Action: 'Stop Azure App Service'
-        WebAppName: ${{ parameters.webApp }}
-        ResourceGroupName: ${{ parameters.webAppResourceGroup}}
         SpecifySlotOrASE: true
-        Slot: ${{ parameters.webAppSlot }}
-      condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
+      ${{ else }}
+        Action: 'Delete Slot'
+      WebAppName: ${{ parameters.webApp }}
+      ResourceGroupName: ${{ parameters.webAppResourceGroup}}
+      Slot: ${{ parameters.webAppSlot }}
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -61,8 +61,7 @@ steps:
           Write-Host "##vso[task.setVariable variable=skipWebApp]false"
       }
       # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
-      Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"
-      
+      Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"     
       # Copy keepStagingSlot parameter to keepStagingSlot variable so we can use it in conditions.
       Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}""
 

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -35,6 +35,10 @@ parameters:
   type: stepList
   default: []
   displayName: 'Optional steps to execute after production slot deploy, before cleaning up the old slot (when applicable).'
+- name: keepStagingSlot
+  type: boolean
+  default: false
+  displayName: 'When set to true, just stops the staging slot instead of deleting it (only works when webAppSlot != production)'
 
 steps:
 - task: PowerShell@2
@@ -58,6 +62,9 @@ steps:
       }
       # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
       Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"
+      
+      # Copy keepStagingSlot parameter to keepStagingSlot variable so we can use it in conditions.
+      Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'
@@ -104,4 +111,15 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), not(variables['keepStagingSlot']))
+  
+  - task: AzureAppServiceManage@0
+    displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      Action: 'Stop Azure App Service'
+      WebAppName: ${{ parameters.webApp }}
+      ResourceGroupName: ${{ parameters.webAppResourceGroup}}
+      SpecifySlotOrASE: true
+      Slot: ${{ parameters.webAppSlot }}
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), variables['keepStagingSlot'])

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -62,8 +62,8 @@ steps:
       }
       # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
       Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"     
-      # Copy keepStagingSlot parameter to keepStagingSlotVar variable so we can use it in conditions.
-      Write-Host "##vso[task.setVariable variable=keepStagingSlotVar]${{ parameters.keepStagingSlot }}""
+      # Copy keepStagingSlot parameter to keepStagingSlot variable so we can use it in conditions.
+      Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}"
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'
@@ -110,7 +110,7 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), not(variables['keepStagingSlotVar']))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), not(variables['keepStagingSlot']))
   
   - task: AzureAppServiceManage@0
     displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
@@ -121,4 +121,4 @@ steps:
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       SpecifySlotOrASE: true
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), variables['keepStagingSlotVar'])
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), variables['keepStagingSlot'])

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -102,23 +102,25 @@ steps:
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
 
-  - task: AzureAppServiceManage@0
-    displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
-    inputs:
-      azureSubscription: ${{ parameters.azureSubscription }}
-      Action: 'Delete Slot'
-      WebAppName: ${{ parameters.webApp }}
-      ResourceGroupName: ${{ parameters.webAppResourceGroup}}
-      Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), not(variables['keepStagingSlot']))
+  - ${{ if not(variables['keepStagingSlot']) }}
+    - task: AzureAppServiceManage@0
+      displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
+      inputs:
+        azureSubscription: ${{ parameters.azureSubscription }}
+        Action: 'Delete Slot'
+        WebAppName: ${{ parameters.webApp }}
+        ResourceGroupName: ${{ parameters.webAppResourceGroup}}
+        Slot: ${{ parameters.webAppSlot }}
+      condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
   
-  - task: AzureAppServiceManage@0
-    displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
-    inputs:
-      azureSubscription: ${{ parameters.azureSubscription }}
-      Action: 'Stop Azure App Service'
-      WebAppName: ${{ parameters.webApp }}
-      ResourceGroupName: ${{ parameters.webAppResourceGroup}}
-      SpecifySlotOrASE: true
-      Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), variables['keepStagingSlot'])
+  - ${{ if variables['keepStagingSlot'] }}
+    - task: AzureAppServiceManage@0
+      displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
+      inputs:
+        azureSubscription: ${{ parameters.azureSubscription }}
+        Action: 'Stop Azure App Service'
+        WebAppName: ${{ parameters.webApp }}
+        ResourceGroupName: ${{ parameters.webAppResourceGroup}}
+        SpecifySlotOrASE: true
+        Slot: ${{ parameters.webAppSlot }}
+      condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -62,8 +62,6 @@ steps:
       }
       # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
       Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"     
-      # Copy keepStagingSlot parameter to keepStagingSlot variable so we can use it in conditions.
-      Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}"
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'
@@ -102,7 +100,7 @@ steps:
   - ${{ each step in parameters.postDeploySteps }}:
     - ${{ step }} 
 
-  - ${{ if not(variables['keepStagingSlot']) }}
+  - ${{ if not(parameters.keepStagingSlot }}
 
     - task: AzureAppServiceManage@0
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Remove slot'
@@ -114,8 +112,8 @@ steps:
         Slot: ${{ parameters.webAppSlot }}
       condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'))
   
-  - ${{ if variables['keepStagingSlot'] }}
-  
+  - ${{ if parameters.keepStagingSlot }}
+
     - task: AzureAppServiceManage@0
       displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
       inputs:

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -64,7 +64,7 @@ steps:
       Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"
       
       # Copy keepStagingSlot parameter to keepStagingSlot variable so we can use it in conditions.
-      Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}
+      Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}""
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'

--- a/azure/pipelines/deploy/web-app.yml
+++ b/azure/pipelines/deploy/web-app.yml
@@ -62,8 +62,8 @@ steps:
       }
       # Copy webAppSlot parameter to webAppSlotName variable so we can use it in conditions.
       Write-Host "##vso[task.setVariable variable=webAppSlotName]${{ parameters.webAppSlot }}"     
-      # Copy keepStagingSlot parameter to keepStagingSlot variable so we can use it in conditions.
-      Write-Host "##vso[task.setVariable variable=keepStagingSlot]${{ parameters.keepStagingSlot }}""
+      # Copy keepStagingSlot parameter to keepStagingSlotVar variable so we can use it in conditions.
+      Write-Host "##vso[task.setVariable variable=keepStagingSlotVar]${{ parameters.keepStagingSlot }}""
 
 - task: AzureRmWebAppDeployment@4
   displayName: '${{ coalesce(parameters.label, parameters.module) }} - Deploy'
@@ -110,7 +110,7 @@ steps:
       WebAppName: ${{ parameters.webApp }}
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), not(variables['keepStagingSlot']))
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), not(variables['keepStagingSlotVar']))
   
   - task: AzureAppServiceManage@0
     displayName: '${{ coalesce(parameters.label, parameters.module) }} - Stop slot'
@@ -121,4 +121,4 @@ steps:
       ResourceGroupName: ${{ parameters.webAppResourceGroup}}
       SpecifySlotOrASE: true
       Slot: ${{ parameters.webAppSlot }}
-    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), variables['keepStagingSlot'])
+    condition: and(succeeded(), ne(variables['skipWebApp'], 'true'), ne(variables['webAppSlotName'], 'production'), variables['keepStagingSlotVar'])


### PR DESCRIPTION
Added a new parameter: **keepStagingSlot**, which is false by default.
So if you don't specify it, the pipeline will still delete the staging slot after the swap (same behaviour as before)

Yet if you set this parameter to **true** then the staging slot will not be deleted after swap.
Instead, it will be stopped.