### PR TITLE
Use NuGetAuthenticate and a commandline task to restore packages. Thi…

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -122,17 +122,20 @@ steps:
       path: $(NUGET_PACKAGES)
     condition: ne(variables.NUGET_PACKAGES, '')
   
-- task: DotNetCoreCLI@2
-  displayName: 'DotNet Restore'
-  inputs: 
-    command: 'restore'
-    projects: ${{ parameters.Solution }}
-    ${{ if parameters.NuGetConfigPath }}:
-      feedsToUse: 'config'
-      nugetConfigPath: ${{ parameters.NuGetConfigPath }}
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate with NuGet'
+  inputs:
     ${{ if parameters.ExternalFeedCredentials }}:
-      externalFeedCredentials: ${{ parameters.ExternalFeedCredentials }}
-      restoreArguments: --locked-mode
+        nuGetServiceConnections: ${{ parameters.ExternalFeedCredentials }}
+
+- task: PowerShell@2
+  displayName: 'DotNet Restore'
+  inputs:
+    targetType: 'inline'
+    script: |    
+        $command = "dotnet restore ${{ parameters.Solution }}"        
+        if ("${{ parameters.NuGetConfigPath }}" -ne $null) { $command += " --configfile `"${{ parameters.NuGetConfigPath }}`"" }
+        Invoke-Expression $command
 
 - ${{ if and( ne(parameters.NoTests, true), ne(parameters.WithPlatinaTestInit, false) ) }}:
   - task: PowerShell@2


### PR DESCRIPTION
Use NuGetAuthenticate and a commandline task to restore packages. This fixes issues with PackageSourceMapping, where the `DotNetCoreCLI@2` task requires `feed-` prefixes in the source mapping configuration

See
https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping
> There is a limitation when using the DotNetCoreCLI@2 Azure Pipelines task which can be worked around by using feed- prefixes in your source mapping configuration. It is recommended however to use NuGetAuthenticate for your authentication needs and call the dotnet cli directly from a script task. See [microsoft/azure-pipelines-tasks#15542](https://github.com/microsoft/azure-pipelines-tasks/issues/15542).