### PR TITLE
Fix selecting working directory with solution filter file

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -145,7 +145,7 @@ steps:
       pwsh: true
       script: |
         $isDefaultSolution = $parameters.Solution -eq "*.sln?(x)" ? $True : $False
-        Write-Host "Is default solution: $isDefaultSolution"
+        Write-Host "Is default solution: $isDefaultSolution => $parameters.Solution"
 
         $solutionFile = ($parameters.Solution -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : $parameters.Solution : $parameters.Solution
         Write-Host "Using solution file '$solutionFile'."

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -144,10 +144,10 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        $isDefaultSolution = ${{ parameters.Solution }} -eq "*.sln?(x)" ? $True : $False
+        $isDefaultSolution = "${{ parameters.Solution }}" -eq "*.sln?(x)" ? $True : $False
         Write-Host "Is default solution: $isDefaultSolution => ${{ parameters.Solution }}"
 
-        $solutionFile = (${{ parameters.Solution }} -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ parameters.Solution }}" : "${{ parameters.Solution }}"
+        $solutionFile = ("${{ parameters.Solution }}" -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ parameters.Solution }}" : "${{ parameters.Solution }}"
         Write-Host "Using solution file '$solutionFile'."
         Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"
 

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -144,6 +144,9 @@ steps:
       targetType: inline
       pwsh: true
       script: |
+        $isDefaultSolution = $parameters.Solution -eq "*.sln?(x)" ? $True : $False
+        Write-Host "Is default solution: $isDefaultSolution"
+
         $solutionFile = ($parameters.Solution -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : $parameters.Solution : $parameters.Solution
         Write-Host "Using solution file '$solutionFile'."
         Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -147,7 +147,7 @@ steps:
         $isDefaultSolution = ${{ parameters.Solution }} -eq "*.sln?(x)" ? $True : $False
         Write-Host "Is default solution: $isDefaultSolution => ${{ parameters.Solution }}"
 
-        $solutionFile = (${{ parameters.Solution }} -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : ${{ parameters.Solution }} : ${{ parameters.Solution }}
+        $solutionFile = (${{ parameters.Solution }} -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ parameters.Solution }}" : "${{ parameters.Solution }}"
         Write-Host "Using solution file '$solutionFile'."
         Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"
 

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -157,7 +157,7 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        Get-ChildItem -Filter ${{ variables.SolutionFile }} | Foreach-Object {
+        Get-ChildItem -Filter $(SolutionFile) | Foreach-Object {
           dotnet msbuild /target:BeginPlatinaTestInit "$($_.FullName)"
         }
         # Ignore msbuild errors because targets might not be present in projects.
@@ -212,7 +212,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          Get-ChildItem -Filter ${{ variables.SolutionFile }} | Foreach-Object {
+          Get-ChildItem -Filter $(SolutionFile) | Foreach-Object {
             dotnet msbuild /target:EndPlatinaTestInit "$($_.FullName)"
           }
           # Ignore msbuild errors because targets might not be present in projects.
@@ -230,7 +230,7 @@ steps:
         script: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
-          $solutionDir = (Get-Item "${{ variables.SolutionFile }}" | Select-Object -First 1).Directory
+          $solutionDir = (Get-Item $(SolutionFile) | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {
@@ -256,7 +256,7 @@ steps:
         inlineScript: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest.
-          $solutionDir = (Get-Item "${{ variables.SolutionFile }}" | Select-Object -First 1).Directory
+          $solutionDir = (Get-Item $(SolutionFile) | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -145,6 +145,7 @@ steps:
       pwsh: true
       script: |
         $solutionFile = ($parameters.Solution -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : $parameters.Solution : $parameters.Solution
+        Write-Host "Using solution file '$solutionFile'."
         Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"
 
 - ${{ if and( ne(parameters.NoTests, true), ne(parameters.WithPlatinaTestInit, false) ) }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -144,9 +144,6 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        $isDefaultSolution = "${{ parameters.Solution }}" -eq "*.sln?(x)" ? $True : $False
-        Write-Host "Is default solution: $isDefaultSolution => ${{ parameters.Solution }}"
-
         $solutionFile = ("${{ parameters.Solution }}" -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ parameters.Solution }}" : "${{ parameters.Solution }}"
         Write-Host "Using solution file '$solutionFile'."
         Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -213,7 +213,7 @@ steps:
         script: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
-          $solutionDir = (Get-Item "${{ parameters.Solution }}").Directory
+          $solutionDir = (Get-Item "${{ parameters.Solution }}" | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {
@@ -239,7 +239,7 @@ steps:
         inlineScript: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest.
-          $solutionDir = (Get-Item "${{ parameters.Solution }}").Directory
+          $solutionDir = (Get-Item "${{ parameters.Solution }}" | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -144,10 +144,10 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        $isDefaultSolution = $parameters.Solution -eq "*.sln?(x)" ? $True : $False
-        Write-Host "Is default solution: $isDefaultSolution => $parameters.Solution"
+        $isDefaultSolution = ${{ parameters.Solution }} -eq "*.sln?(x)" ? $True : $False
+        Write-Host "Is default solution: $isDefaultSolution => ${{ parameters.Solution }}"
 
-        $solutionFile = ($parameters.Solution -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : $parameters.Solution : $parameters.Solution
+        $solutionFile = (${{ parameters.Solution }} -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : ${{ parameters.Solution }} : ${{ parameters.Solution }}
         Write-Host "Using solution file '$solutionFile'."
         Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"
 

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -2,7 +2,7 @@
 parameters:
 - name: Solution
   type: string
-  default: '*.sln*' # Support both '.sln' and '.slnx'
+  default: '*.sln?(x)' # Support both '.sln' and '.slnx'
   displayName: 'Optional solution to process, use this if you have multiple solutions.'
 
 - name: BuildConfiguration
@@ -134,13 +134,26 @@ steps:
       externalFeedCredentials: ${{ parameters.ExternalFeedCredentials }}
       restoreArguments: --locked-mode
 
+# 'Solution' parameter default is a glob pattern that is supported by DotNetCoreCLI task.
+# Glob patterns are not supported natively in PowerShell.
+# So resolve the solution file if default is used. Prefer '.slnx' over '.sln' if both are present.
+- ${{ if ne(parameters.NoTests, 'true') }}:
+  - task: PowerShell@2
+    displayName: Set 'SolutionFile' variable
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        $solutionFile = ($parameters.Solution -eq "*.sln?(x)") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : $parameters.Solution : $parameters.Solution
+        Write-Host "##vso[task.setvariable variable=SolutionFile]$solutionFile"
+
 - ${{ if and( ne(parameters.NoTests, true), ne(parameters.WithPlatinaTestInit, false) ) }}:
   - task: PowerShell@2
     displayName: 'Platina Begin Test Initialization'
     inputs:
       targetType: 'inline'
       script: |
-        Get-ChildItem -Filter ${{ parameters.Solution }} | Foreach-Object {
+        Get-ChildItem -Filter ${{ variables.SolutionFile }} | Foreach-Object {
           dotnet msbuild /target:BeginPlatinaTestInit "$($_.FullName)"
         }
         # Ignore msbuild errors because targets might not be present in projects.
@@ -195,7 +208,7 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          Get-ChildItem -Filter ${{ parameters.Solution }} | Foreach-Object {
+          Get-ChildItem -Filter ${{ variables.SolutionFile }} | Foreach-Object {
             dotnet msbuild /target:EndPlatinaTestInit "$($_.FullName)"
           }
           # Ignore msbuild errors because targets might not be present in projects.
@@ -213,7 +226,7 @@ steps:
         script: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
-          $solutionDir = (Get-Item "${{ parameters.Solution }}" | Select-Object -First 1).Directory
+          $solutionDir = (Get-Item "${{ variables.SolutionFile }}" | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {
@@ -239,7 +252,7 @@ steps:
         inlineScript: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest.
-          $solutionDir = (Get-Item "${{ parameters.Solution }}" | Select-Object -First 1).Directory
+          $solutionDir = (Get-Item "${{ variables.SolutionFile }}" | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -136,7 +136,8 @@ steps:
 
 # 'Solution' parameter default is a glob pattern that is supported by DotNetCoreCLI task.
 # Glob patterns are not supported natively in PowerShell.
-# So resolve the solution file if default is used. Prefer '.slnx' over '.sln' if both are present.
+# So resolve the solution file if default is used and output as variable. So this can be used for test steps.
+# Prefer '.slnx' over '.sln' if both are present.
 - ${{ if ne(parameters.NoTests, 'true') }}:
   - task: PowerShell@2
     displayName: Set 'SolutionFile' variable

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -94,15 +94,15 @@ runs:
         dotnet-version: ${{ inputs.dotNetSdkVersion }}
       env:
         NUGET_AUTH_TOKEN: ${{ inputs.nuGetAuthToken }}
-    
-    # Set variables.
-    #  - solutionFile: Support for '.sln' & '.slnx' files. Resolve solution file to use for 'dotnet' commands.
-    - name: Set variables
+
+    # Support for '.sln' & '.slnx' files. Resolve solution file to use for 'dotnet' commands.
+    - name: Set 'SolutionFile' variable
       id: "variables"
       shell: pwsh
       run: |
         $solutionFile = ("${{ inputs.solution }}" -eq "") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ inputs.solution }}" : "${{ inputs.solution }}"
-        echo "solutionFile=$solutionFile" >> "$GITHUB_OUTPUT"
+        Write-Host "Using solution file '$solutionFile'."
+        "solutionFile=$solutionFile" >> $env:GITHUB_OUTPUT
 
     - name: DotNet Restore
       shell: pwsh

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -137,7 +137,7 @@ runs:
       run: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
-          $solutionDir = (Get-Item "${{ inputs.solution}}" | Select-Object -First 1).Directory
+          $solutionDir = (Get-Item "${{ inputs.solution }}" | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           foreach($project in (Resolve-Path ${{ inputs.testProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item))

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -137,7 +137,7 @@ runs:
       run: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
-          $solutionDir = (Get-Item "${{ inputs.solution }}").Directory
+          $solutionDir = (Get-Item "${{ inputs.solution}}" | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           foreach($project in (Resolve-Path ${{ inputs.testProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item))

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -101,7 +101,7 @@ runs:
       id: "variables"
       shell: pwsh
       run: |
-        $solutionFile = (${{ inputs.solution }} -eq "") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : ${{ inputs.solution }} : ${{ inputs.solution }}
+        $solutionFile = (${{ inputs.solution }} -eq "") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ inputs.solution }}" : "${{ inputs.solution }}"
         echo "solutionFile=$solutionFile" >> "$GITHUB_OUTPUT"
 
     - name: DotNet Restore

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -11,7 +11,7 @@ inputs:
   solution:
     description: "Optional solution to process, use this if you have multiple solutions or when running on a Windows runner."
     required: false
-    default: "" # Default only supported for Linux runners. Linux interprets wildcards and expands them before it is sent to a command.
+    default: ""
 
   dotNetSdkVersion:
     description: "Specific .NET SDK version to use."
@@ -94,8 +94,11 @@ runs:
         dotnet-version: ${{ inputs.dotNetSdkVersion }}
       env:
         NUGET_AUTH_TOKEN: ${{ inputs.nuGetAuthToken }}
-
-    # Support for '.sln' & '.slnx' files. Resolve solution file to use for 'dotnet' commands.
+    
+    # Support for '.sln' & '.slnx' files. Resolve solution file and output as variable. So this can be used for subsequent 'dotnet' commands.
+    # Prefer '.slnx' over '.sln' when both are present.
+    # Default only supported for Linux runners. Linux interprets wildcards and expands them before it is sent to a command.
+    # When running on Windows, perhaps better to specify the solution file explicitly, for now.
     - name: Set 'SolutionFile' variable
       id: "variables"
       shell: pwsh

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -11,7 +11,7 @@ inputs:
   solution:
     description: "Optional solution to process, use this if you have multiple solutions or when running on a Windows runner."
     required: false
-    default: "*.sln" # Default only supported for Linux runners. Linux interprets wildcards and expands them before it is sent to a command.
+    default: "" # Default only supported for Linux runners. Linux interprets wildcards and expands them before it is sent to a command.
 
   dotNetSdkVersion:
     description: "Specific .NET SDK version to use."
@@ -94,10 +94,19 @@ runs:
         dotnet-version: ${{ inputs.dotNetSdkVersion }}
       env:
         NUGET_AUTH_TOKEN: ${{ inputs.nuGetAuthToken }}
+    
+    # Set variables.
+    #  - solutionFile: Support for '.sln' & '.slnx' files. Resolve solution file to use for 'dotnet' commands.
+    - name: Set variables
+      id: "variables"
+      shell: pwsh
+      run: |
+        $solutionFile = (${{ inputs.solution }} -eq "") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : ${{ inputs.solution }} : ${{ inputs.solution }}
+        echo "solutionFile=$solutionFile" >> "$GITHUB_OUTPUT"
 
     - name: DotNet Restore
       shell: pwsh
-      run: dotnet restore ${{ inputs.solution }}
+      run: dotnet restore ${{ steps.variables.outputs.solutionFile }}
 
     # DotNet restore doesn't restore tools in ./config/dotnet-tools.json, although documentation seems to indicate otherwise.
     # https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools
@@ -107,12 +116,12 @@ runs:
 
     - name: DotNet Build
       shell: pwsh
-      run: dotnet build ${{ inputs.solution }} --configuration ${{ inputs.buildConfiguration }} /p:Platform="${{ inputs.buildPlatform}}" --no-restore
+      run: dotnet build ${{ steps.variables.outputs.solutionFile }} --configuration ${{ inputs.buildConfiguration }} /p:Platform="${{ inputs.buildPlatform}}" --no-restore
 
     - name: DotNet Pack
       shell: pwsh
       if: ${{ inputs.withPack == 'true' }}
-      run: dotnet pack ${{ inputs.solution }} --configuration ${{ inputs.buildConfiguration }} ${{ inputs.postBuildDotnetArgs }} --property:PackageOutputPath=${{ runner.temp }}/nugets
+      run: dotnet pack ${{ steps.variables.outputs.solutionFile }} --configuration ${{ inputs.buildConfiguration }} ${{ inputs.postBuildDotnetArgs }} --property:PackageOutputPath=${{ runner.temp }}/nugets
       # Explicitly pass parameters as environment variables for Platina packaging support.
       env:
         Prerelease: ${{ inputs.prerelease }}
@@ -122,7 +131,7 @@ runs:
       shell: pwsh
       if: ${{ inputs.withPublish == 'true' }}
       run: |
-        dotnet publish ${{ inputs.solution }} --configuration ${{ inputs.buildConfiguration }} ${{ inputs.postBuildDotnetArgs }} --property PublishDir=${{ runner.temp }}/packages
+        dotnet publish ${{ steps.variables.outputs.solutionFile }} --configuration ${{ inputs.buildConfiguration }} ${{ inputs.postBuildDotnetArgs }} --property PublishDir=${{ runner.temp }}/packages
       # Explicitly pass parameters as environment variables for Platina publish support.
       env:
         Prerelease: ${{ inputs.prerelease }}
@@ -137,7 +146,7 @@ runs:
       run: |
           # Sets test coverage default when not provided, defaults depends whether native MTP is configured with .NET 10 or not.
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
-          $solutionDir = (Get-Item "${{ inputs.solution }}" | Select-Object -First 1).Directory
+          $solutionDir = (Get-Item "${{ steps.variables.outputs.solutionFile }}").Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
 
           foreach($project in (Resolve-Path ${{ inputs.testProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item))

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -101,7 +101,7 @@ runs:
       id: "variables"
       shell: pwsh
       run: |
-        $solutionFile = (${{ inputs.solution }} -eq "") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ inputs.solution }}" : "${{ inputs.solution }}"
+        $solutionFile = ("${{ inputs.solution }}" -eq "") ? (Test-Path "*.slnx") ? "*.slnx" : (Test-Path "*.sln") ? "*.sln" : "${{ inputs.solution }}" : "${{ inputs.solution }}"
         echo "solutionFile=$solutionFile" >> "$GITHUB_OUTPUT"
 
     - name: DotNet Restore


### PR DESCRIPTION
- When default is used, detect solution file and output as variable. So this can be used by subsequent test steps.
- Added .slnx support also for github action