### PR TITLE
Fix 'DotNet Test' exit code

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -230,6 +230,7 @@ steps:
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
           $solutionDir = (Get-Item $(SolutionFile) | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
+          $exitCode = 0
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {
             if ( $isMtp ) {
@@ -242,7 +243,13 @@ steps:
               $testCoverageArguments = ( "${{ parameters.TestCoverageArguments }}" -eq "" ) ? @("--collect", "Code Coverage") : "${{ parameters.TestCoverageArguments }}"
               &dotnet test "$_" --logger trx --results-directory $(Agent.TempDirectory) --configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} $testCoverageArguments ${{ parameters.TestArguments }}
             }
+
+            if ( $LASTEXITCODE -gt $exitCode ) {
+              $exitCode = $LASTEXITCODE
+            }
           }
+
+          exit $exitCode
         
   - ${{ else }}:
     - task: AzureCLI@2
@@ -256,6 +263,7 @@ steps:
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest.
           $solutionDir = (Get-Item $(SolutionFile) | Select-Object -First 1).Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
+          $exitCode = 0
 
           Resolve-Path ${{ parameters.TestProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item | Foreach-Object {
             if ( $isMtp ) {
@@ -268,7 +276,13 @@ steps:
               $testCoverageArguments = ( "${{ parameters.TestCoverageArguments }}" -eq "" ) ? @("--collect", "Code Coverage") : "${{ parameters.TestCoverageArguments }}"
               &dotnet test "$_" --logger trx --results-directory $(Agent.TempDirectory) --configuration ${{ parameters.BuildConfiguration }} ${{ parameters.PostBuildDotnetArgs }} $testCoverageArguments ${{ parameters.TestArguments }}
             }
+
+            if ( $LASTEXITCODE -gt $exitCode ) {
+              $exitCode = $LASTEXITCODE
+            }
           }
+
+          exit $exitCode
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -151,6 +151,7 @@ runs:
           # Use '--coverage' when using native MTP, '--collect "Code Coverage"' for MTP over VSTest
           $solutionDir = (Get-Item "${{ steps.variables.outputs.solutionFile }}").Directory
           $isMtp = (Get-Content (Join-Path $solutionDir "global.json") -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).test.runner -eq "Microsoft.Testing.Platform"
+          $exitCode = 0
 
           foreach($project in (Resolve-Path ${{ inputs.testProjectsGlob }} -ErrorAction SilentlyContinue | Get-Item))
           {
@@ -166,7 +167,13 @@ runs:
               $testCoverageArguments = ( "${{ inputs.testCoverageArguments }}" -eq "" ) ? @("--collect", "Code Coverage") : "${{ inputs.testCoverageArguments }}"
               &dotnet test "$($project.FullName)" --logger trx --results-directory ${{ runner.temp }} --configuration ${{ inputs.buildConfiguration }} ${{ inputs.postBuildDotnetArgs }} $testCoverageArguments ${{ inputs.testArguments }}
             }
+
+            if ( $LASTEXITCODE -gt $exitCode ) {
+              $exitCode = $LASTEXITCODE
+            }
           }
+          
+          exit $exitCode
 
     - name: Publish Test Results
       if: ${{ inputs.noTests != 'true' && always() }}


### PR DESCRIPTION
"Task failed successfully" ...

Exit powershell script with highest exit code instead of 'last exit code'.
Last exit code could be a successful test which in turn reports the 'DotNet Test' as (wrongfully) successful.