### PR TITLE
PAT-free authentication for external NuGet feeds

### DIFF
--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -134,11 +134,12 @@ steps:
       path: $(NUGET_PACKAGES)
     condition: ne(variables.NUGET_PACKAGES, '')
 
-- task: NuGetAuthenticate@1
-  displayName: 'Authenticate with NuGet'
-  inputs:
-    feedUrl: ${{ parameters.ExternalFeedUrl }}
-    azureDevOpsServiceConnection: ${{ parameters.AzureDevOpsConnection }}
+- ${{ if and( parameters.ExternalFeedUrl, parameters.AzureDevOpsConnection ) }}:
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate with NuGet'
+    inputs:
+      feedUrl: ${{ parameters.ExternalFeedUrl }}
+      azureDevOpsServiceConnection: ${{ parameters.AzureDevOpsConnection }}
 
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -337,8 +337,9 @@ steps:
         targetType: inline
         script: |
            foreach ($package in (Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
-               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }}" --api-key "${{ inputs.nuGetAuthToken }}"
+               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }}"
            }
+
   - ${{ else }}:
     - ${{ if eq(parameters.InternalFeedName, '') }}:
       # Push NuGets to external feed.

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -337,7 +337,7 @@ steps:
         targetType: inline
         script: |
            foreach ($package in (Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
-               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }}"
+               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }} -ApiKey az"
            }
 
   - ${{ else }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -333,7 +333,7 @@ steps:
   # Push NuGets to external feed with 'dotnet nuget push' command instead.
   # This is because the 'push' command of 'DotNetCoreCLI@2' doesn't support a full nuget NuGet Service Index URL format which is used with 'NuGetAuthenticate' task (see above).
   # And the 'push' command will no longer take new features.
-  - ${{ if parameters.ExternalFeedUrl }}:
+  - ${{ if and(parameters.ExternalFeedUrl, parameters.AzureDevOpsConnection) }}:
     - task: PowerShell@2
       displayName: 'DotNet Push'
       inputs:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -88,6 +88,14 @@ parameters:
   type: boolean
   default: false
   displayName: 'Whether to cache NuGet packages. NUGET_PACKAGES environment variable still needs to be set though.'
+- name: ExternalFeedUrl
+  type: string
+  default: ''
+  displayName: 'Optional URL of external NuGet feed. If this is set, AzureDevOpsConnection is required. Feed URL should be in the NuGet service index format: https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/nuget/v3/index.json.'
+- name: AzureDevOpsConnection
+  type: string
+  default: ''
+  displayName: 'Optional Azure DevOps service connection for authenticating with external feeds.'
 
 - name: AzureSubscription
   type: string
@@ -125,6 +133,12 @@ steps:
         nuget | "$(Agent.OS)"
       path: $(NUGET_PACKAGES)
     condition: ne(variables.NUGET_PACKAGES, '')
+
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate with NuGet'
+  inputs:
+    feedUrl: ${{ parameters.ExternalFeedUrl }}
+    azureDevOpsServiceConnection: ${{ parameters.AzureDevOpsConnection }}
 
 - task: DotNetCoreCLI@2
   displayName: 'DotNet Restore'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -330,6 +330,9 @@ steps:
     - ${{ step }} 
   
 - ${{ if and( eq(parameters.WithPack, 'true'), eq(parameters.WithRelease, 'true') ) }}:
+  # Push NuGets to external feed with 'dotnet nuget push' command instead.
+  # This is because the 'push' command of 'DotNetCoreCLI@2' doesn't support a full nuget NuGet Service Index URL format which is used with 'NuGetAuthenticate' task (see above).
+  # And the 'push' command will no longer take new features.
   - ${{ if parameters.ExternalFeedUrl }}:
     - task: PowerShell@2
       displayName: 'DotNet Push'

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -337,7 +337,7 @@ steps:
         targetType: inline
         script: |
            foreach ($package in (Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
-               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }} --api-key az"
+               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }}" --api-key az
            }
 
   - ${{ else }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -336,7 +336,7 @@ steps:
       inputs:
         targetType: inline
         script: |
-           foreach ($package in (Get-ChildItem -Path ${{ runner.temp }}/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
+           foreach ($package in (Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
                dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }}" --api-key "${{ inputs.nuGetAuthToken }}"
            }
   - ${{ else }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -337,7 +337,7 @@ steps:
         targetType: inline
         script: |
            foreach ($package in (Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
-               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }} -ApiKey az"
+               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }} --api-key az"
            }
 
   - ${{ else }}:

--- a/azure/pipelines/dotnet/ci.yml
+++ b/azure/pipelines/dotnet/ci.yml
@@ -330,25 +330,35 @@ steps:
     - ${{ step }} 
   
 - ${{ if and( eq(parameters.WithPack, 'true'), eq(parameters.WithRelease, 'true') ) }}:
-  - ${{ if eq(parameters.InternalFeedName, '') }}:
-    # Push NuGets to external feed.
-    - task: DotNetCoreCLI@2
+  - ${{ if parameters.ExternalFeedUrl }}:
+    - task: PowerShell@2
       displayName: 'DotNet Push'
       inputs:
-        command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/nugets/*.nupkg;$(Build.ArtifactStagingDirectory)/nugets/*.snupkg;!$(Build.ArtifactStagingDirectory)/nugets/*.symbols.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: ${{ parameters.ExternalFeedCredentials }}
-
-  - ${{ if ne(parameters.InternalFeedName, '') }}:
-    # Push NuGets to internal feed.
-    - task: DotNetCoreCLI@2
-      displayName: 'DotNet Push'
-      inputs:
-        command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/nugets/*.nupkg;$(Build.ArtifactStagingDirectory)/nugets/*.snupkg;!$(Build.ArtifactStagingDirectory)/nugets/*.symbols.nupkg'
-        nuGetFeedType: 'internal'
-        publishVstsFeed: ${{ parameters.InternalFeedName }}
+        targetType: inline
+        script: |
+           foreach ($package in (Get-ChildItem -Path ${{ runner.temp }}/nugets -Recurse -Include *.nupkg, *.snupkg | Where-Object { $_.Name -notlike "*.symbols.nupkg" })) {
+               dotnet nuget push $package.FullName --source "${{ parameters.ExternalFeedUrl }}" --api-key "${{ inputs.nuGetAuthToken }}"
+           }
+  - ${{ else }}:
+    - ${{ if eq(parameters.InternalFeedName, '') }}:
+      # Push NuGets to external feed.
+      - task: DotNetCoreCLI@2
+        displayName: 'DotNet Push'
+        inputs:
+          command: 'push'
+          packagesToPush: '$(Build.ArtifactStagingDirectory)/nugets/*.nupkg;$(Build.ArtifactStagingDirectory)/nugets/*.snupkg;!$(Build.ArtifactStagingDirectory)/nugets/*.symbols.nupkg'
+          nuGetFeedType: 'external'
+          publishFeedCredentials: ${{ parameters.ExternalFeedCredentials }}
+  
+    - ${{ if ne(parameters.InternalFeedName, '') }}:
+      # Push NuGets to internal feed.
+      - task: DotNetCoreCLI@2
+        displayName: 'DotNet Push'
+        inputs:
+          command: 'push'
+          packagesToPush: '$(Build.ArtifactStagingDirectory)/nugets/*.nupkg;$(Build.ArtifactStagingDirectory)/nugets/*.snupkg;!$(Build.ArtifactStagingDirectory)/nugets/*.symbols.nupkg'
+          nuGetFeedType: 'internal'
+          publishVstsFeed: ${{ parameters.InternalFeedName }}
 
   # The above task does publish the .snupkgs, but Visual Studio can't seem to consume them from the artifact feed yet?
   # Therefore, also publish the .pdb to the SymbolServer of this organization.

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -98,6 +98,7 @@ inputs:
 runs:
   using: composite
   steps:
+    # Login in Azure CLI context provided with a service principal.
     - uses: azure/login@v1
       if: ${{ inputs.azureClientId != '' && inputs.azureTenantId != '' }}
       name: Azure CLI Login
@@ -106,6 +107,9 @@ runs:
         tenant-id: ${{ inputs.azureTenantId }}
         allow-no-subscriptions: true
 
+    # Simplifies Azure DevOps Central Feed Service authentication. Fetches access token for Azure DevOps and sets this as an environment variale.
+    # Assuming the workflow is authenticated using OIDC (Azure CLI login step).
+    # Additionally it can also setup needed environment variables for nuget & npm authentication.
     - uses: microsoft/setup-cfs@main
       if: ${{ inputs.externalFeedUrl != '' }}
       name: Setup CFS

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -83,15 +83,15 @@ inputs:
     required: false
     default: ""
   externalFeedUrl:
-    description: "External feed URL for private feeds."
+    description: "External feed URL for private feeds. Feed URL should be in format https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/"
     required: false
     default: ""
   azureClientId:
-    description: "Azure Client ID for authenticating with Azure for Azure Artifacts or to run 'dotnet test' under Azure CLI context. So you can access Azure resources (like App Configuration, Key Vault, etc) with authenticated credentials."
+    description: "Azure Client ID for authenticating with Azure Artifacts."
     required: false
     default: "" 
   azureTenantId:
-    description: "Azure Tenant ID for authenticating with Azure for Azure Artifacts or to run 'dotnet test' under Azure CLI context. So you can access Azure resources (like App Configuration, Key Vault, etc) with authenticated credentials."
+    description: "Azure Tenant ID for authenticating with Azure Artifacts."
     required: false
     default: ""
 
@@ -99,7 +99,7 @@ runs:
   using: composite
   steps:
     - uses: azure/login@v1
-      if: ${{ inputs.externalFeedUrl != '' }}
+      if: ${{ inputs.azureClientId != '' && inputs.azureTenantId != '' }}
       name: Azure CLI Login
       with:
         client-id: ${{ inputs.azureClientId }}

--- a/github/actions/dotnet-ci/action.yml
+++ b/github/actions/dotnet-ci/action.yml
@@ -82,10 +82,38 @@ inputs:
     description: "Personal Access Token for publishing symbols to Azure Artifacts symbol server."
     required: false
     default: ""
+  externalFeedUrl:
+    description: "External feed URL for private feeds."
+    required: false
+    default: ""
+  azureClientId:
+    description: "Azure Client ID for authenticating with Azure for Azure Artifacts or to run 'dotnet test' under Azure CLI context. So you can access Azure resources (like App Configuration, Key Vault, etc) with authenticated credentials."
+    required: false
+    default: "" 
+  azureTenantId:
+    description: "Azure Tenant ID for authenticating with Azure for Azure Artifacts or to run 'dotnet test' under Azure CLI context. So you can access Azure resources (like App Configuration, Key Vault, etc) with authenticated credentials."
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
+    - uses: azure/login@v1
+      if: ${{ inputs.externalFeedUrl != '' }}
+      name: Azure CLI Login
+      with:
+        client-id: ${{ inputs.azureClientId }}
+        tenant-id: ${{ inputs.azureTenantId }}
+        allow-no-subscriptions: true
+
+    - uses: microsoft/setup-cfs@main
+      if: ${{ inputs.externalFeedUrl != '' }}
+      name: Setup CFS
+      with:
+        feed-url: ${{ inputs.externalFeedUrl }}
+        nuget: true
+        npm-config: true
+
     - uses: actions/setup-dotnet@v5
       if: ${{ inputs.dotNetSdkVersion != '' || (inputs.nuGetSourceUrl != '' && inputs.nuGetAuthToken != '') }}
       name: Setup DotNet NuGet Feed
@@ -116,6 +144,9 @@ runs:
     - name: DotNet Tool Restore
       shell: pwsh
       run: dotnet tool restore
+
+    - if: ${{ hashFiles('./.github/actions/ci-beforeBuildSteps/action.yml') != '' }}
+      uses: ./.github/actions/ci-beforeBuildSteps
 
     - name: DotNet Build
       shell: pwsh


### PR DESCRIPTION
Allow PAT-free authentication for external NuGet feeds.

**Azure DevOps**
- Added 'ExternalFeedUrl' & 'AzureDevOpsConnection' parameters.
- Uses [NuGetAuthenticate](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-authenticate-v1) task to authenticate with external feed when parameters are provided.
- DotNetCoreCLI remains responsible for 'dotnet restore'.
- When pushing nugets, use 'dotnet nuget push' via PowerShell instead of 'DotNetCoreCLI' task when parameters are provided... To re-use 'ExternalFeedUrl'.

> The restore and push commands of this .NET Core CLI task no longer take new features and only critical bugs are addressed.

- Script remains backwards compatible with 'ExternalFeedCredentials' if only this parameter is provided.

**GitHub**
- Added 'azureClientId' & 'azureTenantId' input parameters to login Azure CLI context.
- Added 'externalFeedUrl' and use [microsoft/setup-cfs](https://github.com/microsoft/setup-cfs) to do the nuget & npm feed authentication bootstrapping.
- Added 'ci-beforeBuildSteps' to inject things like 'npm ci' & 'npm build' scripts after the steps above & before building the solution.